### PR TITLE
stateless functional component로 변경

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,10 +1,7 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-import CssBaseline from '@material-ui/core/CssBaseline';
+import { AppBar, Toolbar, Typography, CssBaseline } from '@material-ui/core';
 
 const styles = {
   root: {
@@ -12,10 +9,7 @@ const styles = {
   },
 };
 
-function Navigation(props) {
-  const { classes } = props;
-
-  return (
+const Navigation = memo(({ classes }) => (
     <>
       <CssBaseline />
       <div className={classes.root}>
@@ -28,8 +22,7 @@ function Navigation(props) {
         </AppBar>
       </div>
     </>
-  );
-}
+))
 
 Navigation.propTypes = {
   classes: PropTypes.object.isRequired,


### PR DESCRIPTION
컴포넌트 내부에 state나 method가 사용되지 않고 props만 내려받아서 사용하는 경우에는 functional component로 구현하는게 좋음 + React.memo 메서드를 활용해서 memoize 처리까지